### PR TITLE
Add additional fields to bane and boon listing

### DIFF
--- a/src/components/banes/single-item-bane.js
+++ b/src/components/banes/single-item-bane.js
@@ -46,6 +46,7 @@ function SingleItemPageBane({ bane }) {
             {bane.name}
           </h2>
           <p><strong>Duration: </strong>{bane.duration}</p>
+          <p><strong>Invocation Time: </strong>{bane.invocationTime}</p>
           <p><strong>Power Level: </strong>{bane.power.map((item, index) => {
               if (index < bane.power.length - 1) return `${item}/ `;
               return item;
@@ -69,6 +70,12 @@ function SingleItemPageBane({ bane }) {
           <p>{bane.description}</p>
           <p><strong>Effect</strong></p>
           <div>{parseStrToHtml(bane.effect)}</div>
+          {bane.special ? 
+              <div>
+                <p><strong>Special</strong></p> 
+                {parseStrToHtml(bane.special)} 
+              </div>
+            : null}
           <p></p> 
         </div>
       </div>

--- a/src/components/boons/single-item-boon.js
+++ b/src/components/boons/single-item-boon.js
@@ -59,6 +59,12 @@ const classes = useStyles();
           <p>{boon.description}</p>
           <p><strong>Effect</strong></p>
           <div>{parseStrToHtml(boon.effect)}</div>
+          {boon.special ? 
+              <div>
+                <p><strong>Special</strong></p> 
+                {parseStrToHtml(boon.special)} 
+              </div>
+            : null}
           <p></p> 
         </div>
       </div>

--- a/src/templates/allBanes.js
+++ b/src/templates/allBanes.js
@@ -209,6 +209,7 @@ const BanesPageContent = ({ location, data }) => {
               <p></p>
               <p></p>
               <p><strong>Duration: </strong>{data.duration}</p>
+              <p><strong>Invocation Time: </strong>{data.invocationTime}</p>
               <p><strong>Power Level: </strong>{data.power.map((item, index) => {
                   if (index < data.power.length - 1) return `${item}/ `;
                   return item;
@@ -232,6 +233,12 @@ const BanesPageContent = ({ location, data }) => {
               <p>{data.description}</p>
               <p><strong>Effect</strong></p>
               <div className={classes.effect}>{parseStrToHtml(data.effect)}</div>
+              {data.special ? 
+                <div>
+                  <p><strong>Special</strong></p> 
+                  {parseStrToHtml(data.special)} 
+                </div>
+              : null}
               <p></p> 
               <Divider />
             </div>

--- a/src/templates/allBoons.js
+++ b/src/templates/allBoons.js
@@ -219,6 +219,12 @@ const BoonsPage = ({ location }) => {
               <p>{data.description}</p>
               <p><strong>Effect</strong></p>
               {parseStrToHtml(data.effect)}
+              {data.special ? 
+                <div>
+                  <p><strong>Special</strong></p> 
+                  {parseStrToHtml(data.special)} 
+                </div>
+              : null}
               <p></p>
               <Divider /> 
             </div>


### PR DESCRIPTION
Changes:
* Banes and boons now have the special section (borrowed from how it's done for feats)
* Also, banes now list their invocation time. Mostly to be in line with the rule book (some banes like Spying and Truthfulness have a differing listing).

Copy of the MR I opened in the other repo